### PR TITLE
Task 235: Fix Y axis for burndown to display what type of points are being used

### DIFF
--- a/src/main/java/ui/metrics/burndown/Burndown.java
+++ b/src/main/java/ui/metrics/burndown/Burndown.java
@@ -20,9 +20,9 @@ public class Burndown extends StackPane {
     }
 
     private void init() {
-        Tab taskBurndownTab = createBurndownTab("Task", new Icon(BoxiconsRegular.CLIPBOARD), this.service.getTaskData());
-        Tab usBurndownTab = createBurndownTab("User Story", new Icon(BoxiconsRegular.USER), this.service.getUserStoryData());
-        Tab bvBurndownTab = createBurndownTab("Business Value", new Icon(BoxiconsRegular.BRIEFCASE), this.service.getBusinessValueData());
+        Tab taskBurndownTab = createBurndownTab("Task", "Fractional Story Points", new Icon(BoxiconsRegular.CLIPBOARD), this.service.getTaskData());
+        Tab usBurndownTab = createBurndownTab("User Story", "Full Story Points", new Icon(BoxiconsRegular.USER), this.service.getUserStoryData());
+        Tab bvBurndownTab = createBurndownTab("Business Value", "Business Value Points", new Icon(BoxiconsRegular.BRIEFCASE), this.service.getBusinessValueData());
 
         tabPane.getTabs().setAll(taskBurndownTab, usBurndownTab, bvBurndownTab);
         tabPane.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
@@ -31,7 +31,7 @@ public class Burndown extends StackPane {
         this.service.start();
     }
 
-    private Tab createBurndownTab(String name, Icon icon, BurndownService.Data data) {
+    private Tab createBurndownTab(String name, String valueUnits, Icon icon, BurndownService.Data data) {
         StackPane root = new StackPane();
 
         Tab tab = new Tab(name);
@@ -43,7 +43,7 @@ public class Burndown extends StackPane {
         CategoryAxis date = new CategoryAxis();
         date.setLabel("Date");
         NumberAxis value = new NumberAxis();
-        value.setLabel("Value");
+        value.setLabel(valueUnits);
 
         XYChart.Series<String, Number> ideal = new XYChart.Series<>(data.getIdeal());
         ideal.setName("Ideal");


### PR DESCRIPTION
# SER516 - Team Boston Peer Review

### US: 235

### Description of Changes:
Added new descriptive Y axis for task, user story, and business value burndown charts. Here are some screenshots:
![image](https://github.com/cgjeffries/SER516-Team-Boston/assets/15178122/f2bf63ac-8002-4794-af3f-a0cbc4d2a963)
![image](https://github.com/cgjeffries/SER516-Team-Boston/assets/15178122/bce01686-9716-4d37-93c6-0f0596304526)
![image](https://github.com/cgjeffries/SER516-Team-Boston/assets/15178122/fd5092eb-a356-4136-8442-54289fb8c2d9)

### Peer Review Checklist:
- [x] Taiga updated
- [x] Code builds and runs
- [x] Code is formatted properly
- [x] JavaDoc comments are included on essential methods
- [x] Code is clearly documented and understandable
- [x] Static analysis checks are passing
- [x] Test cases are passing
- [x] Critical non-ui code is covered by unit tests
- [x] All task requirements are fulfilled
- [x] All user story requirements are fulfilled
