### PR TITLE
US 293 - Overlay multiple sprints on the burndown chart

### DIFF
--- a/src/main/java/taiga/model/query/sprint/Sprint.java
+++ b/src/main/java/taiga/model/query/sprint/Sprint.java
@@ -214,4 +214,9 @@ public class Sprint {
     public int hashCode() {
         return Objects.hash(slug, id);
     }
+
+    @Override
+    public String toString(){
+        return this.getName();
+    }
 }

--- a/src/main/java/taiga/util/UserStoryUtils.java
+++ b/src/main/java/taiga/util/UserStoryUtils.java
@@ -58,7 +58,7 @@ public class UserStoryUtils {
      * @param story The user story to extract business value from
      * @return The business value of the user story
      */
-    public static Double getBusinessValueForUserStory(UserStory story) {
+    public static Double getBusinessValueForUserStory(UserStoryInterface story) {
         if (!userStoryCustomAttributes.containsKey(story.getProject())) {
             try {
                 userStoryCustomAttributes.put(story.getProject(), loadBvAttribute(story.getProject()));

--- a/src/main/java/ui/components/Multiselect.java
+++ b/src/main/java/ui/components/Multiselect.java
@@ -1,0 +1,12 @@
+package ui.components;
+
+import javafx.scene.control.ListView;
+import javafx.scene.control.SelectionMode;
+
+public class Multiselect<T> extends ListView<T> {
+    public Multiselect() {
+        getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+        setMaxHeight(100);
+    }
+
+}

--- a/src/main/java/ui/metrics/burndown/Burndown.java
+++ b/src/main/java/ui/metrics/burndown/Burndown.java
@@ -1,8 +1,5 @@
 package ui.metrics.burndown;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableMap;
@@ -85,8 +82,12 @@ public class Burndown extends StackPane {
         return tab;
     }
 
-    public void SelectSprints(List<Sprint> sprints) {
-        this.service.recalculate(sprints);
+    public void selectSprints(List<Sprint> sprints) {
+        this.selectSprints(sprints, false);
+    }
+
+    public void selectSprints(List<Sprint> sprints, boolean overlay) {
+        this.service.recalculate(sprints, overlay);
     }
 
     public void focusFirstTab() {

--- a/src/main/java/ui/metrics/burndown/Burndown.java
+++ b/src/main/java/ui/metrics/burndown/Burndown.java
@@ -82,10 +82,20 @@ public class Burndown extends StackPane {
         return tab;
     }
 
+    /**
+     * Choose which sprints will be displayed in the burndown graphs
+     * @param sprints the list of sprints to display the various burndown graphs for
+     */
     public void selectSprints(List<Sprint> sprints) {
         this.selectSprints(sprints, false);
     }
 
+    /**
+     * Choose which sprints will be displayed in the burndown graphs
+     * @param sprints the list of sprints to display the various burndown graphs for
+     * @param overlay Whether or not to make the burndown charts overlay one another. if false the
+     *                burndown charts will be displayed chronologically.
+     */
     public void selectSprints(List<Sprint> sprints, boolean overlay) {
         this.service.recalculate(sprints, overlay);
     }

--- a/src/main/java/ui/metrics/burndown/Burndown.java
+++ b/src/main/java/ui/metrics/burndown/Burndown.java
@@ -85,7 +85,7 @@ public class Burndown extends StackPane {
         return tab;
     }
 
-    public void SslectSprints(List<Sprint> sprints) {
+    public void SelectSprints(List<Sprint> sprints) {
         this.service.recalculate(sprints);
     }
 

--- a/src/main/java/ui/metrics/burndown/Burndown.java
+++ b/src/main/java/ui/metrics/burndown/Burndown.java
@@ -1,6 +1,7 @@
 package ui.metrics.burndown;
 
 import java.util.List;
+import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableMap;
 import javafx.scene.chart.*;
@@ -102,6 +103,10 @@ public class Burndown extends StackPane {
 
     public void focusFirstTab() {
         tabPane.getSelectionModel().selectFirst();
+    }
+
+    public ReadOnlyBooleanProperty serviceRunning(){
+        return this.service.runningProperty();
     }
 
     public void cancel() {

--- a/src/main/java/ui/metrics/burndown/Burndown.java
+++ b/src/main/java/ui/metrics/burndown/Burndown.java
@@ -1,5 +1,8 @@
 package ui.metrics.burndown;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import javafx.scene.chart.*;
 import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.Tab;
@@ -32,7 +35,7 @@ public class Burndown extends StackPane {
         this.service.start();
     }
 
-    private Tab createBurndownTab(String name, String valueUnits, Icon icon, BurndownService.Data data) {
+    private Tab createBurndownTab(String name, String valueUnits, Icon icon, HashMap<Sprint, BurndownService.Data> dataMap) {
         StackPane root = new StackPane();
 
         Tab tab = new Tab(name);
@@ -46,14 +49,18 @@ public class Burndown extends StackPane {
         NumberAxis value = new NumberAxis();
         value.setLabel(valueUnits);
 
-        XYChart.Series<String, Number> ideal = new XYChart.Series<>(data.getIdeal());
-        ideal.setName("Ideal");
-        XYChart.Series<String, Number> current = new XYChart.Series<>(data.getCalculated());
-        current.setName("Current");
-
         AreaChart<String, Number> chart = new AreaChart<>(date, value);
 
-        chart.getData().addAll(ideal, current);
+        for(Sprint sprint : dataMap.keySet()) {
+            BurndownService.Data data = dataMap.get(sprint);
+
+            XYChart.Series<String, Number> ideal = new XYChart.Series<>(data.getIdeal());
+            ideal.setName("Ideal (" + sprint.getName() + ")");
+            XYChart.Series<String, Number> current = new XYChart.Series<>(data.getCalculated());
+            current.setName("Current (" + sprint.getName() + ")");
+
+            chart.getData().addAll(ideal, current);
+        }
 
         chart.setAnimated(false);
         chart.visibleProperty().bind(this.service.runningProperty().not());
@@ -67,7 +74,7 @@ public class Burndown extends StackPane {
     }
 
     public void switchSprint(Sprint sprint) {
-        this.service.recalculate(sprint);
+        this.service.recalculate(new ArrayList<>(Arrays.asList(sprint))); //TODO: actually pass multiple sprints
     }
 
     public void focusFirstTab() {

--- a/src/main/java/ui/screens/BaseMetricConfiguration.java
+++ b/src/main/java/ui/screens/BaseMetricConfiguration.java
@@ -116,7 +116,7 @@ public abstract class BaseMetricConfiguration extends Screen {
         screenManager.switchScreen("project_selection");
     }
 
-    private static class SprintComboboxCellFactory implements Callback<ListView<Sprint>, ListCell<Sprint>> {
+    protected static class SprintComboboxCellFactory implements Callback<ListView<Sprint>, ListCell<Sprint>> {
         @Override
         public ListCell<Sprint> call(ListView<Sprint> sprintListView) {
             return new ListCell<>() {

--- a/src/main/java/ui/screens/BurndownScreen.java
+++ b/src/main/java/ui/screens/BurndownScreen.java
@@ -1,7 +1,15 @@
 package ui.screens;
 
+import atlantafx.base.theme.Styles;
+import javafx.beans.binding.Bindings;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
+import settings.Settings;
+import taiga.model.query.project.Project;
 import taiga.model.query.sprint.Sprint;
 import ui.components.screens.ScreenManager;
 import ui.metrics.burndown.Burndown;
@@ -9,6 +17,7 @@ import ui.metrics.burndown.Burndown;
 public class BurndownScreen extends BaseMetricConfiguration {
 
     private Burndown burndown;
+    private ComboBox<Sprint> endSprint;
 
     /**
      * Create a screen instance
@@ -47,9 +56,24 @@ public class BurndownScreen extends BaseMetricConfiguration {
         this.burndown.switchSprint(sprint_combobox.getValue());
     }
 
+
+    @Override
+    protected void beforeParameterMount() {
+        SimpleObjectProperty<Project> currentProject = Settings.get().getAppModel().getCurrentProject();
+        endSprint = new ComboBox<>();
+        SprintComboboxCellFactory cellFactory = new SprintComboboxCellFactory();
+        endSprint.setButtonCell(cellFactory.call(null));
+        endSprint.setCellFactory(cellFactory);
+        endSprint.itemsProperty().bind(Bindings.createObjectBinding(
+                () -> FXCollections.observableList(currentProject.get().getSprints()), currentProject));
+        endSprint.setPrefWidth(150);
+    }
+
     @Override
     protected VBox parameters() {
-        return null;
+        Label label = new Label("End Sprint");
+        label.getStyleClass().add(Styles.TEXT_BOLD);
+        return new VBox(label, endSprint);
     }
 
     @Override

--- a/src/main/java/ui/screens/BurndownScreen.java
+++ b/src/main/java/ui/screens/BurndownScreen.java
@@ -43,6 +43,7 @@ public class BurndownScreen extends BaseMetricConfiguration {
     @Override
     protected void beforeVisualizationMount() {
         this.burndown = new Burndown();
+        checkComboBox.disableProperty().bind(this.burndown.serviceRunning());
     }
 
     @Override
@@ -94,7 +95,6 @@ public class BurndownScreen extends BaseMetricConfiguration {
 
         checkComboBox = new CheckComboBox<>(FXCollections.observableList(currentProject.get().getSprints()));
         checkComboBox.getCheckModel().check(FXCollections.observableList(currentProject.get().getSprints()).size() - 1);
-
         checkComboBox.setPrefWidth(150);
 
         overlayLabel = new Label("Overlay Sprints");

--- a/src/main/java/ui/screens/BurndownScreen.java
+++ b/src/main/java/ui/screens/BurndownScreen.java
@@ -2,6 +2,7 @@ package ui.screens;
 
 import atlantafx.base.theme.Styles;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.SimpleObjectProperty;
@@ -54,10 +55,14 @@ public class BurndownScreen extends BaseMetricConfiguration {
     protected void afterVisualizationMount() {
         checkComboBox.getCheckModel().getCheckedItems().addListener(
             (ListChangeListener<? super Sprint>) (change) -> {
-                this.burndown.SelectSprints(checkComboBox.getCheckModel().getCheckedItems());
+                ArrayList<Sprint> list = new ArrayList<>(checkComboBox.getCheckModel().getCheckedItems());
+                Collections.reverse(list);
+                this.burndown.SelectSprints(list);
             });
 
-        this.burndown.SelectSprints(checkComboBox.getCheckModel().getCheckedItems());
+        ArrayList<Sprint> list = new ArrayList<>(checkComboBox.getCheckModel().getCheckedItems());
+        Collections.reverse(list);
+        this.burndown.SelectSprints(list);
     }
 
 

--- a/src/main/java/ui/screens/BurndownScreen.java
+++ b/src/main/java/ui/screens/BurndownScreen.java
@@ -3,6 +3,8 @@ package ui.screens;
 import atlantafx.base.theme.Styles;
 import java.util.ArrayList;
 import java.util.Collections;
+
+import javafx.application.Platform;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
@@ -77,6 +79,7 @@ public class BurndownScreen extends BaseMetricConfiguration {
                     overlayLabel.setVisible(false);
                     updateDisplayedSprints(false);
                 }
+                Platform.runLater(() -> checkComboBox.hide());
             });
 
         overlayCheckBox.selectedProperty().addListener((observable, oldValue, newValue) -> {

--- a/src/main/java/ui/screens/BurndownScreen.java
+++ b/src/main/java/ui/screens/BurndownScreen.java
@@ -3,16 +3,15 @@ package ui.screens;
 import atlantafx.base.theme.Styles;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
-import javafx.beans.binding.Bindings;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
-import javafx.util.StringConverter;
 import org.controlsfx.control.CheckComboBox;
 import settings.Settings;
 import taiga.model.query.project.Project;
@@ -26,6 +25,9 @@ public class BurndownScreen extends BaseMetricConfiguration {
     private ComboBox<Sprint> endSprint;
 
     private CheckComboBox<Sprint> checkComboBox;
+
+    private Label overlayLabel;
+    private CheckBox overlayCheckBox;
 
     /**
      * Create a screen instance
@@ -48,6 +50,13 @@ public class BurndownScreen extends BaseMetricConfiguration {
         return this.burndown;
     }
 
+    protected void updateDisplayedSprints(boolean overlay){
+        ArrayList<Sprint> list = new ArrayList<>(checkComboBox.getCheckModel().getCheckedItems());
+        Collections.reverse(list);
+        this.burndown.selectSprints(list, overlay);
+    }
+
+
     /**
      * Adds the switch sprint functionality to the sprint dropdown after the page is rendered.
      */
@@ -55,14 +64,25 @@ public class BurndownScreen extends BaseMetricConfiguration {
     protected void afterVisualizationMount() {
         checkComboBox.getCheckModel().getCheckedItems().addListener(
             (ListChangeListener<? super Sprint>) (change) -> {
-                ArrayList<Sprint> list = new ArrayList<>(checkComboBox.getCheckModel().getCheckedItems());
-                Collections.reverse(list);
-                this.burndown.SelectSprints(list);
+                if(checkComboBox.getCheckModel().getCheckedItems().size() > 1){
+                    overlayCheckBox.setVisible(true);
+                    overlayCheckBox.setDisable(false);
+                    overlayLabel.setVisible(true);
+                    updateDisplayedSprints(overlayCheckBox.isSelected());
+                }
+                else{
+                    overlayCheckBox.setVisible(false);
+                    overlayCheckBox.setDisable(true);
+                    overlayLabel.setVisible(false);
+                    updateDisplayedSprints(false);
+                }
             });
 
-        ArrayList<Sprint> list = new ArrayList<>(checkComboBox.getCheckModel().getCheckedItems());
-        Collections.reverse(list);
-        this.burndown.SelectSprints(list);
+        overlayCheckBox.selectedProperty().addListener((observable, oldValue, newValue) -> {
+            updateDisplayedSprints(overlayCheckBox.isSelected());
+        });
+
+        updateDisplayedSprints(overlayCheckBox.isSelected());
     }
 
 
@@ -77,21 +97,20 @@ public class BurndownScreen extends BaseMetricConfiguration {
 
         checkComboBox.setPrefWidth(150);
 
-
-//        endSprint = new ComboBox<>();
-//        SprintComboboxCellFactory cellFactory = new SprintComboboxCellFactory();
-//        endSprint.setButtonCell(cellFactory.call(null));
-//        endSprint.setCellFactory(cellFactory);
-//        endSprint.itemsProperty().bind(Bindings.createObjectBinding(
-//                () -> FXCollections.observableList(currentProject.get().getSprints()), currentProject));
-//        endSprint.setPrefWidth(150);
+        overlayLabel = new Label("Overlay Sprints");
+        overlayLabel.setVisible(false);
+        overlayCheckBox = new CheckBox();
+        overlayCheckBox.setVisible(false);
+        overlayCheckBox.setDisable(true);
     }
 
     @Override
     protected VBox parameters() {
         Label label = new Label("Select Sprints");
         label.getStyleClass().add(Styles.TEXT_BOLD);
-        return new VBox(label, checkComboBox);
+        HBox hbox = new HBox(checkComboBox, overlayLabel, overlayCheckBox);
+        hbox.setSpacing(5);
+        return new VBox(label, hbox);
     }
 
     @Override

--- a/src/main/java/ui/services/BurndownService.java
+++ b/src/main/java/ui/services/BurndownService.java
@@ -1,6 +1,7 @@
 package ui.services;
 
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.List;
 
 import javafx.application.Platform;
@@ -16,7 +17,7 @@ import ui.metrics.burndown.TaskBurndown;
 import ui.metrics.burndown.UserStoryBurndown;
 
 public class BurndownService extends Service<Object> {
-    private Sprint sprint;
+    private List<Sprint> sprints;
 
     private final TaskBurndown taskBurndown;
     private final UserStoryBurndown userStoryBurndown;
@@ -34,10 +35,11 @@ public class BurndownService extends Service<Object> {
         this.taskBurndownData = new Data();
         this.userStoryBurndownData = new Data();
         this.businessValueBurndownData = new Data();
+        sprints = new ArrayList<>();
     }
 
-    public void recalculate(Sprint sprint) {
-        this.sprint = sprint;
+    public void recalculate(List<Sprint> sprint) {
+        this.sprints = sprint;
         this.restart();
     }
 
@@ -67,19 +69,22 @@ public class BurndownService extends Service<Object> {
         return new Task<>() {
             @Override
             protected Object call() throws Exception {
-                if (sprint == null) {
+                if (sprints.isEmpty()) {
                     return null;
                 }
 
-                List<BurnDownEntry> taskXYData = taskBurndown.calculate(sprint);
-                List<BurnDownEntry> userStoryXYData = userStoryBurndown.calculate(sprint);
-                List<BurnDownEntry> businessValueXYData = businessValueBurndown.calculate(sprint);
+                for(Sprint sprint : sprints) {
+                    List<BurnDownEntry> taskXYData = taskBurndown.calculate(sprint);
+                    List<BurnDownEntry> userStoryXYData = userStoryBurndown.calculate(sprint);
+                    List<BurnDownEntry> businessValueXYData =
+                        businessValueBurndown.calculate(sprint);
 
-                Platform.runLater(() -> {
-                    updateBurndownData(taskBurndownData, taskXYData);
-                    updateBurndownData(userStoryBurndownData, userStoryXYData);
-                    updateBurndownData(businessValueBurndownData, businessValueXYData);
-                });
+                    Platform.runLater(() -> {
+                        updateBurndownData(taskBurndownData, taskXYData);
+                        updateBurndownData(userStoryBurndownData, userStoryXYData);
+                        updateBurndownData(businessValueBurndownData, businessValueXYData);
+                    });
+                }
 
                 return null;
             }

--- a/src/main/java/ui/services/BurndownService.java
+++ b/src/main/java/ui/services/BurndownService.java
@@ -49,7 +49,7 @@ public class BurndownService extends Service<Object> {
     public void recalculate(List<Sprint> sprints, boolean overlay) {
         this.sprints = sprints;
         this.overlay = overlay;
-        Platform.runLater(this::restart);
+        this.restart();
     }
 
     public ObservableMap<Sprint, Data> getTaskData() {

--- a/src/main/java/ui/services/BurndownService.java
+++ b/src/main/java/ui/services/BurndownService.java
@@ -8,6 +8,7 @@ import java.util.List;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.collections.ObservableMap;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
 import javafx.scene.chart.XYChart;
@@ -24,18 +25,19 @@ public class BurndownService extends Service<Object> {
     private final UserStoryBurndown userStoryBurndown;
     private final BusinessValueBurndown businessValueBurndown;
 
-    private final HashMap<Sprint, Data> taskBurndownData;
-    private final HashMap<Sprint, Data> userStoryBurndownData;
-    private final HashMap<Sprint, Data> businessValueBurndownData;
+    private final ObservableMap<Sprint, Data> taskBurndownData;
+    private final ObservableMap<Sprint, Data> userStoryBurndownData;
+    private final ObservableMap<Sprint, Data> businessValueBurndownData;
 
     public BurndownService() {
         this.taskBurndown = new TaskBurndown();
         this.userStoryBurndown = new UserStoryBurndown();
         this.businessValueBurndown = new BusinessValueBurndown();
 
-        this.taskBurndownData = new HashMap<>();
-        this.userStoryBurndownData = new HashMap<>();
-        this.businessValueBurndownData = new HashMap<>();
+        this.taskBurndownData = FXCollections.observableHashMap();
+
+        this.userStoryBurndownData = FXCollections.observableHashMap();
+        this.businessValueBurndownData = FXCollections.observableHashMap();
         sprints = new ArrayList<>();
     }
 
@@ -44,15 +46,15 @@ public class BurndownService extends Service<Object> {
         this.restart();
     }
 
-    public HashMap<Sprint, Data> getTaskData() {
+    public ObservableMap<Sprint, Data> getTaskData() {
         return this.taskBurndownData;
     }
 
-    public HashMap<Sprint, Data> getUserStoryData() {
+    public ObservableMap<Sprint, Data> getUserStoryData() {
         return this.userStoryBurndownData;
     }
 
-    public HashMap<Sprint, Data> getBusinessValueData() {
+    public ObservableMap<Sprint, Data> getBusinessValueData() {
         return this.businessValueBurndownData;
     }
 
@@ -92,7 +94,7 @@ public class BurndownService extends Service<Object> {
         };
     }
 
-    private void updateBurndownData(HashMap<Sprint, Data> burndownDataMap, List<BurnDownEntry> entries, Sprint sprint) {
+    private void updateBurndownData(ObservableMap<Sprint, Data> burndownDataMap, List<BurnDownEntry> entries, Sprint sprint) {
         Data burndownData = new Data();
 
         SimpleDateFormat format = new SimpleDateFormat("MMM dd");

--- a/src/main/java/ui/services/BurndownService.java
+++ b/src/main/java/ui/services/BurndownService.java
@@ -76,6 +76,14 @@ public class BurndownService extends Service<Object> {
                     return null;
                 }
 
+                Platform.runLater(() -> {
+                    taskBurndownData.clear();
+                    userStoryBurndownData.clear();
+                    businessValueBurndownData.clear();
+                });
+
+
+
                 for(Sprint sprint : sprints) {
                     List<BurnDownEntry> taskXYData = taskBurndown.calculate(sprint);
                     List<BurnDownEntry> userStoryXYData = userStoryBurndown.calculate(sprint);

--- a/src/main/java/ui/services/BurndownService.java
+++ b/src/main/java/ui/services/BurndownService.java
@@ -49,7 +49,7 @@ public class BurndownService extends Service<Object> {
     public void recalculate(List<Sprint> sprints, boolean overlay) {
         this.sprints = sprints;
         this.overlay = overlay;
-        this.restart();
+        Platform.runLater(this::restart);
     }
 
     public ObservableMap<Sprint, Data> getTaskData() {

--- a/src/main/java/ui/services/BurndownService.java
+++ b/src/main/java/ui/services/BurndownService.java
@@ -2,6 +2,7 @@ package ui.services;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import javafx.application.Platform;
@@ -23,18 +24,18 @@ public class BurndownService extends Service<Object> {
     private final UserStoryBurndown userStoryBurndown;
     private final BusinessValueBurndown businessValueBurndown;
 
-    private final BurndownService.Data taskBurndownData;
-    private final BurndownService.Data userStoryBurndownData;
-    private final BurndownService.Data businessValueBurndownData;
+    private final HashMap<Sprint, Data> taskBurndownData;
+    private final HashMap<Sprint, Data> userStoryBurndownData;
+    private final HashMap<Sprint, Data> businessValueBurndownData;
 
     public BurndownService() {
         this.taskBurndown = new TaskBurndown();
         this.userStoryBurndown = new UserStoryBurndown();
         this.businessValueBurndown = new BusinessValueBurndown();
 
-        this.taskBurndownData = new Data();
-        this.userStoryBurndownData = new Data();
-        this.businessValueBurndownData = new Data();
+        this.taskBurndownData = new HashMap<>();
+        this.userStoryBurndownData = new HashMap<>();
+        this.businessValueBurndownData = new HashMap<>();
         sprints = new ArrayList<>();
     }
 
@@ -43,15 +44,15 @@ public class BurndownService extends Service<Object> {
         this.restart();
     }
 
-    public Data getTaskData() {
+    public HashMap<Sprint, Data> getTaskData() {
         return this.taskBurndownData;
     }
 
-    public Data getUserStoryData() {
+    public HashMap<Sprint, Data> getUserStoryData() {
         return this.userStoryBurndownData;
     }
 
-    public Data getBusinessValueData() {
+    public HashMap<Sprint, Data> getBusinessValueData() {
         return this.businessValueBurndownData;
     }
 
@@ -80,9 +81,9 @@ public class BurndownService extends Service<Object> {
                         businessValueBurndown.calculate(sprint);
 
                     Platform.runLater(() -> {
-                        updateBurndownData(taskBurndownData, taskXYData);
-                        updateBurndownData(userStoryBurndownData, userStoryXYData);
-                        updateBurndownData(businessValueBurndownData, businessValueXYData);
+                        updateBurndownData(taskBurndownData, taskXYData, sprint);
+                        updateBurndownData(userStoryBurndownData, userStoryXYData, sprint);
+                        updateBurndownData(businessValueBurndownData, businessValueXYData, sprint);
                     });
                 }
 
@@ -91,10 +92,14 @@ public class BurndownService extends Service<Object> {
         };
     }
 
-    private void updateBurndownData(Data burndownData, List<BurnDownEntry> entries) {
+    private void updateBurndownData(HashMap<Sprint, Data> burndownDataMap, List<BurnDownEntry> entries, Sprint sprint) {
+        Data burndownData = new Data();
+
         SimpleDateFormat format = new SimpleDateFormat("MMM dd");
         burndownData.setIdeal(entries.stream().map(d -> new XYChart.Data<>(format.format(d.getDate()), (Number) d.getIdeal())).toList());
         burndownData.setCalculated(entries.stream().map(d -> new XYChart.Data<>(format.format(d.getDate()), (Number) d.getCurrent())).toList());
+
+        burndownDataMap.put(sprint, burndownData);
     }
 
     public static class Data {


### PR DESCRIPTION
# US: 293

### Description of Changes:
* Added the ability to display multiple sprints at once in the burndown chart
* Added option to make burndown charts overlay one another

### PR Submitter Checklist:
- [x] Taiga updated
- [x] Code Compiles
- [x] Tests Pass
- [x] Essential code is commented using docstrings
- [x] US acceptance criteria are met
- [x] Static analysis checks pass


### Reviewer Checklist (Copy into your review):
```markdown
# Review comments

# Review Checklist
- [ ] Taiga updated
- [ ] Code Compiles
- [ ] Tests Pass
- [ ] Essential code is commented using docstrings
- [ ] US acceptance criteria are met
- [ ] Static analysis checks pass
```
