### PR TITLE
US- 296: Allow Lead Time for arbitrary timeframe

### DIFF
--- a/src/main/java/ui/metrics/leadtime/LeadTime.java
+++ b/src/main/java/ui/metrics/leadtime/LeadTime.java
@@ -1,5 +1,6 @@
 package ui.metrics.leadtime;
 
+import java.util.Date;
 import javafx.collections.ObservableList;
 import javafx.scene.chart.CategoryAxis;
 import javafx.scene.chart.NumberAxis;
@@ -91,6 +92,10 @@ public class LeadTime extends StackPane {
 
     public void switchSprint(Sprint sprint) {
         this.service.recalculate(sprint);
+    }
+
+    public void switchDates(Integer projectId, Date startDate, Date endDate){
+        this.service.recalculate(projectId, startDate, endDate);
     }
 
     public void focusFirstTab() {

--- a/src/main/java/ui/screens/LeadTimeScreen.java
+++ b/src/main/java/ui/screens/LeadTimeScreen.java
@@ -75,6 +75,8 @@ public class LeadTimeScreen extends BaseMetricConfiguration {
             if (leadTime != null) {
                 calendarUpdate();
             }
+
+            //disable all days in the EndDate picker before the start date
             endDate.setDayCellFactory(picker -> new DateCell() {
                 @Override
                 public void updateItem(LocalDate date, boolean empty) {
@@ -87,6 +89,15 @@ public class LeadTimeScreen extends BaseMetricConfiguration {
             if (leadTime != null) {
                 calendarUpdate();
             }
+
+            //disable all days in the StartDate picker after the end date
+            startDate.setDayCellFactory(picker -> new DateCell() {
+                @Override
+                public void updateItem(LocalDate date, boolean empty) {
+                    super.updateItem(date, empty);
+                    setDisable(empty || date.isAfter(endDate.getValue()));
+                }
+            });
         });
     }
 

--- a/src/main/java/ui/screens/LeadTimeScreen.java
+++ b/src/main/java/ui/screens/LeadTimeScreen.java
@@ -1,12 +1,23 @@
 package ui.screens;
 
+import atlantafx.base.theme.Styles;
+import java.time.LocalDate;
+import javafx.scene.control.DateCell;
+import javafx.scene.control.DatePicker;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
+import settings.Settings;
 import taiga.model.query.sprint.Sprint;
 import ui.components.screens.ScreenManager;
 import ui.metrics.leadtime.LeadTime;
+import ui.util.DateUtil;
 
 public class LeadTimeScreen extends BaseMetricConfiguration {
     private LeadTime leadTime;
+    private DatePicker startDate;
+    private DatePicker endDate;
 
     public LeadTimeScreen(ScreenManager screenManager, String id, String fxmlName) {
         super(screenManager, id, fxmlName);
@@ -17,9 +28,44 @@ public class LeadTimeScreen extends BaseMetricConfiguration {
         this.leadTime = new LeadTime();
     }
 
+    private VBox createDatePickerBox(String name, DatePicker datePicker) {
+        Label text = new Label(name);
+        text.getStyleClass().add(Styles.TEXT_BOLD);
+        return new VBox(text, datePicker);
+    }
+
     @Override
     protected Pane visualization() {
         return this.leadTime;
+    }
+
+    @Override
+    protected void beforeParameterMount() {
+        this.startDate = new DatePicker();
+        this.endDate = new DatePicker();
+        this.startDate.valueProperty().addListener((observable, oldValue, newValue) -> {
+            if (leadTime != null) {
+                leadTime.switchDates(Settings.get().getAppModel().getCurrentProject().get().getId(),
+                    DateUtil.toDate(newValue), DateUtil.toDate(endDate.getValue()));
+            }
+            endDate.setDayCellFactory(picker -> new DateCell() {
+                @Override
+                public void updateItem(LocalDate date, boolean empty) {
+                    super.updateItem(date, empty);
+                    setDisable(empty || date.isBefore(startDate.getValue().plusDays(1)));
+                }
+            });
+        });
+        this.endDate.valueProperty().addListener((obs, oldValue, newValue) -> {
+            if (leadTime != null) {
+                leadTime.switchDates(Settings.get().getAppModel().getCurrentProject().get().getId(),
+                    DateUtil.toDate(newValue), DateUtil.toDate(endDate.getValue()));
+            }
+        });
+        sprint_combobox.getSelectionModel().selectLast();
+        Sprint selectedSprint = sprint_combobox.getValue();
+        this.startDate.setValue(DateUtil.toLocal(selectedSprint.getEstimatedStart()));
+        this.endDate.setValue(DateUtil.toLocal(selectedSprint.getEstimatedFinish()));
     }
 
     @Override
@@ -37,7 +83,12 @@ public class LeadTimeScreen extends BaseMetricConfiguration {
 
     @Override
     protected Pane parameters() {
-        return null;
+        HBox container = new HBox(
+            createDatePickerBox("Start Date: ", startDate),
+            createDatePickerBox("End Date: ", endDate)
+        );
+        container.setSpacing(5);
+        return container;
     }
 
     @Override

--- a/src/main/java/ui/screens/LeadTimeScreen.java
+++ b/src/main/java/ui/screens/LeadTimeScreen.java
@@ -1,6 +1,7 @@
 package ui.screens;
 
 import atlantafx.base.theme.Styles;
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import javafx.scene.control.DateCell;
 import javafx.scene.control.DatePicker;
@@ -28,6 +29,9 @@ public class LeadTimeScreen extends BaseMetricConfiguration {
         this.leadTime = new LeadTime();
     }
 
+    /**
+     * helper function for creating datePicker boxes in the parameters box
+     */
     private VBox createDatePickerBox(String name, DatePicker datePicker) {
         Label text = new Label(name);
         text.getStyleClass().add(Styles.TEXT_BOLD);
@@ -39,14 +43,37 @@ public class LeadTimeScreen extends BaseMetricConfiguration {
         return this.leadTime;
     }
 
+    /**
+     * update the value of the calendars with the values from the sprint in the sprint combobox
+     */
+    private void calendarUpdate(){
+        if(startDate.getValue() != null && endDate.getValue() != null) {
+            SimpleDateFormat format = new SimpleDateFormat("dd-MMM-yyyy");
+
+            sprint_name.setText(format.format(DateUtil.toDate(startDate.getValue())) + " - " +
+                format.format(DateUtil.toDate(endDate.getValue())));
+            updateLeadTime();
+        }
+    }
+
+    /**
+     * update the Lead Time based on the date range
+     */
+    private void updateLeadTime(){
+        leadTime.switchDates(Settings.get().getAppModel().getCurrentProject().get().getId(),
+            DateUtil.toDate(startDate.getValue()), DateUtil.toDate(endDate.getValue()));
+    }
+
     @Override
     protected void beforeParameterMount() {
+        sprint_name.textProperty().unbind();
+        sprint_name.setText("asdlfjhkjalshhfdkljsagf");
+
         this.startDate = new DatePicker();
         this.endDate = new DatePicker();
         this.startDate.valueProperty().addListener((observable, oldValue, newValue) -> {
             if (leadTime != null) {
-                leadTime.switchDates(Settings.get().getAppModel().getCurrentProject().get().getId(),
-                    DateUtil.toDate(newValue), DateUtil.toDate(endDate.getValue()));
+                calendarUpdate();
             }
             endDate.setDayCellFactory(picker -> new DateCell() {
                 @Override
@@ -58,14 +85,9 @@ public class LeadTimeScreen extends BaseMetricConfiguration {
         });
         this.endDate.valueProperty().addListener((obs, oldValue, newValue) -> {
             if (leadTime != null) {
-                leadTime.switchDates(Settings.get().getAppModel().getCurrentProject().get().getId(),
-                    DateUtil.toDate(newValue), DateUtil.toDate(endDate.getValue()));
+                calendarUpdate();
             }
         });
-        sprint_combobox.getSelectionModel().selectLast();
-        Sprint selectedSprint = sprint_combobox.getValue();
-        this.startDate.setValue(DateUtil.toLocal(selectedSprint.getEstimatedStart()));
-        this.endDate.setValue(DateUtil.toLocal(selectedSprint.getEstimatedFinish()));
     }
 
     @Override
@@ -75,10 +97,19 @@ public class LeadTimeScreen extends BaseMetricConfiguration {
             if (sprint == null) {
                 return;
             }
-            this.leadTime.switchSprint(sprint);
+            this.startDate.setValue(DateUtil.toLocal(sprint.getEstimatedStart()));
+            this.endDate.setValue(DateUtil.toLocal(sprint.getEstimatedFinish()));
+
+            sprint_name.setText(sprint.getName());
+            updateLeadTime();
         });
         sprint_combobox.getSelectionModel().selectLast();
-        this.leadTime.switchSprint(sprint_combobox.getValue());
+
+        Sprint sprint = sprint_combobox.getValue();
+        this.startDate.setValue(DateUtil.toLocal(sprint.getEstimatedStart()));
+        this.endDate.setValue(DateUtil.toLocal(sprint.getEstimatedFinish()));
+        sprint_name.setText(sprint.getName());
+        updateLeadTime();
     }
 
     @Override

--- a/src/main/java/ui/services/LeadTimeService.java
+++ b/src/main/java/ui/services/LeadTimeService.java
@@ -67,7 +67,7 @@ public class LeadTimeService extends Service<Object> {
     }
 
     public void recalculate(Sprint sprint){
-        recalculate(sprint.getId(), sprint.getEstimatedStart(), sprint.getEstimatedFinish());
+        recalculate(sprint.getProject(), sprint.getEstimatedStart(), sprint.getEstimatedFinish());
     }
 
     public void recalculate(Integer projectId, Date startDate, Date endDate){

--- a/src/main/java/ui/services/LeadTimeService.java
+++ b/src/main/java/ui/services/LeadTimeService.java
@@ -4,6 +4,7 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
@@ -11,6 +12,7 @@ import javafx.collections.ObservableList;
 import javafx.concurrent.Service;
 import javafx.concurrent.Task;
 import javafx.scene.chart.XYChart;
+import taiga.model.query.common.Project;
 import taiga.model.query.sprint.Sprint;
 import taiga.model.query.userstories.UserStoryInterface;
 import taiga.util.timeAnalysis.LeadTimeHelper;
@@ -18,7 +20,11 @@ import taiga.util.timeAnalysis.LeadTimeStats;
 import ui.util.DateUtil;
 
 public class LeadTimeService extends Service<Object> {
-    private Sprint sprint;
+//    private Sprint sprint;
+
+    private Integer projectId;
+    private Date startDate;
+    private Date endDate;
 
     private final ObservableList<XYChart.Data<String, Number>> notCreatedStories;
     private final ObservableList<XYChart.Data<String, Number>> inBacklogStories;
@@ -61,15 +67,21 @@ public class LeadTimeService extends Service<Object> {
     }
 
     public void recalculate(Sprint sprint){
-        this.sprint = sprint;
+        recalculate(sprint.getId(), sprint.getEstimatedStart(), sprint.getEstimatedFinish());
+    }
+
+    public void recalculate(Integer projectId, Date startDate, Date endDate){
+        this.projectId = projectId;
+        this.startDate = startDate;
+        this.endDate = endDate;
         this.restart();
     }
 
     private List<LeadTimeStats> getAllLeadTimeStats(){
-        LeadTimeHelper leadTimeHelper = new LeadTimeHelper(this.sprint.getProject());
+        LeadTimeHelper leadTimeHelper = new LeadTimeHelper(projectId);
 
-        LocalDate start = DateUtil.toLocal(sprint.getEstimatedStart());
-        LocalDate end = DateUtil.toLocal(sprint.getEstimatedFinish());
+        LocalDate start = DateUtil.toLocal(startDate);
+        LocalDate end = DateUtil.toLocal(endDate);
         List<LocalDate> dates = start.datesUntil(end.plusDays(1)).toList();
 
         List<LeadTimeStats> leadTimeStats = new ArrayList<>();
@@ -99,7 +111,7 @@ public class LeadTimeService extends Service<Object> {
         return new Task<Object>() {
             @Override
             protected Object call() throws Exception {
-                if (sprint == null) {
+                if (projectId == null || startDate == null || endDate == null) {
                     return null;
                 }
 

--- a/src/main/resources/fxml/app_root.fxml
+++ b/src/main/resources/fxml/app_root.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<fx:root prefHeight="720.0" prefWidth="1280.0" type="StackPane" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root prefHeight="900.0" prefWidth="1600.0" type="StackPane" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <ModalPane fx:id="modalPane" />
       <VBox>


### PR DESCRIPTION
# US: 296

### Description of Changes:
Added ability to select an arbitrary date range for the lead time metric rather than only a specific sprint

### PR Submitter Checklist:
- [x] Taiga updated
- [x] Code Compiles
- [x] Tests Pass
- [x] Essential code is commented using docstrings
- [x] US acceptance criteria are met
- [x] Static analysis checks pass


### Reviewer Checklist (Copy into your review):
```markdown
# Review comments

# Review Checklist
- [ ] Taiga updated
- [ ] Code Compiles
- [ ] Tests Pass
- [ ] Essential code is commented using docstrings
- [ ] US acceptance criteria are met
- [ ] Static analysis checks pass
```
