### PR TITLE
US 229: Visualize lead time as scatter plot

### DIFF
--- a/src/main/java/taiga/util/timeAnalysis/LeadTimeHelper.java
+++ b/src/main/java/taiga/util/timeAnalysis/LeadTimeHelper.java
@@ -65,7 +65,13 @@ public class LeadTimeHelper {
     public List<LeadTimeStoryEntry> getAllStoryLeadTimes() {
         return leadTimeEntryList
                 .stream()
-                .map(entry -> new LeadTimeStoryEntry(entry.getUserStory()))
+                .map(entry -> {
+                    UserStoryInterface story = entry.getUserStory();
+                    if (story.getFinishDate() != null) {
+                        return new LeadTimeStoryEntry(story, story.getCreatedDate(), story.getFinishDate());
+                    }
+                    return new LeadTimeStoryEntry(story, story.getCreatedDate(), null, false);
+                })
                 .toList();
     }
 }

--- a/src/main/java/taiga/util/timeAnalysis/LeadTimeHelper.java
+++ b/src/main/java/taiga/util/timeAnalysis/LeadTimeHelper.java
@@ -62,6 +62,11 @@ public class LeadTimeHelper {
         return stats;
     }
 
+    /**
+     * Get all lead times for the User Stories in the Project
+     *
+     * @return a List of LeadTimeStoryEntry's
+     */
     public List<LeadTimeStoryEntry> getAllStoryLeadTimes() {
         return leadTimeEntryList
                 .stream()

--- a/src/main/java/taiga/util/timeAnalysis/LeadTimeHelper.java
+++ b/src/main/java/taiga/util/timeAnalysis/LeadTimeHelper.java
@@ -4,39 +4,44 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+
 import taiga.api.UserStoryAPI;
 import taiga.model.query.project.Project;
 import taiga.model.query.sprint.UserStoryDetail;
+import taiga.model.query.userstories.UserStoryInterface;
 import taiga.util.UserStoryUtils;
 
 public class LeadTimeHelper {
     private final List<LeadTimeEntry> leadTimeEntryList;
 
     UserStoryAPI userStoryAPI = new UserStoryAPI();
+
     public LeadTimeHelper(Project project) {
         this(project.getId());
     }
 
     /**
      * Create a new LeadTimeHelper. Note that this does make a couple rounds of API Requests so there might be some delay here.
+     *
      * @param projectId the integer Id of the Project whose User Stories we are analyzing the lead time of
      */
-    public LeadTimeHelper(Integer projectId){
+    public LeadTimeHelper(Integer projectId) {
         AtomicReference<List<UserStoryDetail>> userStoryListReference = new AtomicReference<>();
-        userStoryAPI.listProjectUserStories(projectId, result ->{
+        userStoryAPI.listProjectUserStories(projectId, result -> {
             userStoryListReference.set(new ArrayList<>(List.of(result.getContent())));
         }).join();
 
         List<UserStoryDetail> userStoryList = userStoryListReference.get();
 
         this.leadTimeEntryList = userStoryList
-            .parallelStream()
-            .map(UserStoryUtils::getLeadTimeForUserStory)
-            .toList();
+                .parallelStream()
+                .map(UserStoryUtils::getLeadTimeForUserStory)
+                .toList();
     }
 
     /**
      * Return the List of LeadTimeEntries for external processing
+     *
      * @return a List of LeadTimeEntries
      */
     public List<LeadTimeEntry> getLeadTimeEntryList() {
@@ -45,14 +50,22 @@ public class LeadTimeHelper {
 
     /**
      * Given a date, return a LeadTimeStats which gives the user stories at each status level for that date
+     *
      * @param date the date we want the stats for
      * @return a LeadTimeStats object
      */
-    public LeadTimeStats getLeadTimeStatsForDate(Date date){
+    public LeadTimeStats getLeadTimeStatsForDate(Date date) {
         LeadTimeStats stats = new LeadTimeStats(date);
-        for(LeadTimeEntry entry : leadTimeEntryList){
+        for (LeadTimeEntry entry : leadTimeEntryList) {
             stats.addStory(entry.getUserStory(), entry.getStatusForDate(date));
         }
         return stats;
+    }
+
+    public List<LeadTimeStoryEntry> getAllStoryLeadTimes() {
+        return leadTimeEntryList
+                .stream()
+                .map(entry -> new LeadTimeStoryEntry(entry.getUserStory()))
+                .toList();
     }
 }

--- a/src/main/java/taiga/util/timeAnalysis/LeadTimeStoryEntry.java
+++ b/src/main/java/taiga/util/timeAnalysis/LeadTimeStoryEntry.java
@@ -3,21 +3,32 @@ package taiga.util.timeAnalysis;
 import taiga.model.query.userstories.UserStoryInterface;
 
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 public class LeadTimeStoryEntry {
+    private final UserStoryInterface story;
     private final Date startDate;
     private final Date endDate;
+    private final boolean valid;
 
 
     /**
      * Create a lead time entry for a user story. Different from {@link LeadTimeEntry} in that
      * this class only tracks the time elapsed between creation and completion, not its status history.
-     *
-     * @param userStory
      */
-    public LeadTimeStoryEntry(UserStoryInterface userStory) {
-        this.startDate = userStory.getCreatedDate();
-        this.endDate = userStory.getFinishDate();
+    public LeadTimeStoryEntry(UserStoryInterface story, Date start, Date end, boolean valid) {
+        this.story = story;
+        this.startDate = start;
+        this.endDate = end;
+        this.valid = valid;
+    }
+
+    public LeadTimeStoryEntry(UserStoryInterface story, Date start, Date end) {
+        this(story, start, end, true);
+    }
+
+    public UserStoryInterface get() {
+        return story;
     }
 
     public Date getStartDate() {
@@ -35,11 +46,20 @@ public class LeadTimeStoryEntry {
         return endDate.getTime() - startDate.getTime();
     }
 
+    public Long getDaysTaken() {
+        return TimeUnit.MILLISECONDS.toDays(getTimeTaken());
+    }
+
+    public boolean isValid() {
+        return valid;
+    }
+
     @Override
     public String toString() {
         return "LeadTimeStoryEntry{" +
                 "startDate=" + startDate +
                 ", endDate=" + endDate +
+                ", valid=" + valid +
                 '}';
     }
 }

--- a/src/main/java/taiga/util/timeAnalysis/LeadTimeStoryEntry.java
+++ b/src/main/java/taiga/util/timeAnalysis/LeadTimeStoryEntry.java
@@ -1,0 +1,45 @@
+package taiga.util.timeAnalysis;
+
+import taiga.model.query.userstories.UserStoryInterface;
+
+import java.util.Date;
+
+public class LeadTimeStoryEntry {
+    private final Date startDate;
+    private final Date endDate;
+
+
+    /**
+     * Create a lead time entry for a user story. Different from {@link LeadTimeEntry} in that
+     * this class only tracks the time elapsed between creation and completion, not its status history.
+     *
+     * @param userStory
+     */
+    public LeadTimeStoryEntry(UserStoryInterface userStory) {
+        this.startDate = userStory.getCreatedDate();
+        this.endDate = userStory.getFinishDate();
+    }
+
+    public Date getStartDate() {
+        return startDate;
+    }
+
+    public Date getEndDate() {
+        return endDate;
+    }
+
+    public Long getTimeTaken() {
+        if (startDate == null || endDate == null) {
+            return 0L;
+        }
+        return endDate.getTime() - startDate.getTime();
+    }
+
+    @Override
+    public String toString() {
+        return "LeadTimeStoryEntry{" +
+                "startDate=" + startDate +
+                ", endDate=" + endDate +
+                '}';
+    }
+}

--- a/src/main/java/ui/metrics/leadtime/LeadTime.java
+++ b/src/main/java/ui/metrics/leadtime/LeadTime.java
@@ -1,10 +1,7 @@
 package ui.metrics.leadtime;
 
 import javafx.collections.ObservableList;
-import javafx.scene.chart.CategoryAxis;
-import javafx.scene.chart.NumberAxis;
-import javafx.scene.chart.StackedAreaChart;
-import javafx.scene.chart.XYChart;
+import javafx.scene.chart.*;
 import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
@@ -19,23 +16,24 @@ public class LeadTime extends StackPane {
 
     private final TabPane tabPane;
 
-    public LeadTime(){
+    public LeadTime() {
         this.service = new LeadTimeService();
         this.tabPane = new TabPane();
         this.init();
     }
 
-    private void init(){
+    private void init() {
         Tab usLeadTimeTab = createLeadTimeTab(
-            "User Story",
-            new Icon(BoxiconsRegular.USER),
-            this.service.getInBacklogStories(),
-            this.service.getInSprintStories(),
-            this.service.getInProgressStories(),
-            this.service.getReadyForTestStories(),
-            this.service.getDoneStories());
+                "CFD",
+                new Icon(BoxiconsRegular.LINE_CHART),
+                this.service.getInBacklogStories(),
+                this.service.getInSprintStories(),
+                this.service.getInProgressStories(),
+                this.service.getReadyForTestStories(),
+                this.service.getDoneStories());
+        Tab usCycleTimeTab = createStoryLeadTimeTab("Scatter Plot", new Icon(BoxiconsRegular.CHART), this.service.getStoryLeadTimes());
 
-        tabPane.getTabs().setAll(usLeadTimeTab);
+        tabPane.getTabs().setAll(usLeadTimeTab, usCycleTimeTab);
         tabPane.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
 
         getChildren().add(tabPane);
@@ -43,12 +41,12 @@ public class LeadTime extends StackPane {
     }
 
     private Tab createLeadTimeTab(
-        String name, Icon icon,
-        ObservableList<XYChart.Data<String, Number>> inBacklog,
-        ObservableList<XYChart.Data<String, Number>> inSprint,
-        ObservableList<XYChart.Data<String, Number>> inProgress,
-        ObservableList<XYChart.Data<String, Number>> readyForTest,
-        ObservableList<XYChart.Data<String, Number>> done){
+            String name, Icon icon,
+            ObservableList<XYChart.Data<String, Number>> inBacklog,
+            ObservableList<XYChart.Data<String, Number>> inSprint,
+            ObservableList<XYChart.Data<String, Number>> inProgress,
+            ObservableList<XYChart.Data<String, Number>> readyForTest,
+            ObservableList<XYChart.Data<String, Number>> done) {
         StackPane root = new StackPane();
 
         Tab tab = new Tab(name);
@@ -77,6 +75,37 @@ public class LeadTime extends StackPane {
 
         chart.getData().addAll(doneSeries, readyForTestSeries, inProgressSeries, inSprintSeries, inBacklogSeries);
 
+
+        chart.setAnimated(false);
+        chart.visibleProperty().bind(this.service.runningProperty().not());
+
+        root.getChildren().add(chart);
+        root.getChildren().add(progress);
+
+        tab.setContent(root);
+
+        return tab;
+    }
+
+    private Tab createStoryLeadTimeTab(String name, Icon icon, ObservableList<XYChart.Data<String, Number>> data) {
+        StackPane root = new StackPane();
+
+        Tab tab = new Tab(name);
+        tab.setGraphic(icon);
+
+        ProgressIndicator progress = new ProgressIndicator(-1d);
+        progress.visibleProperty().bind(this.service.runningProperty());
+
+        CategoryAxis date = new CategoryAxis();
+        date.setLabel("End Date");
+        NumberAxis value = new NumberAxis();
+        value.setLabel("Lead Time (Days)");
+
+        XYChart.Series<String, Number> points = new XYChart.Series<>(data);
+
+        ScatterChart<String, Number> chart = new ScatterChart<>(date, value);
+
+        chart.getData().addAll(points);
 
         chart.setAnimated(false);
         chart.visibleProperty().bind(this.service.runningProperty().not());

--- a/src/main/java/ui/services/LeadTimeService.java
+++ b/src/main/java/ui/services/LeadTimeService.java
@@ -15,11 +15,13 @@ import taiga.model.query.sprint.Sprint;
 import taiga.model.query.userstories.UserStoryInterface;
 import taiga.util.timeAnalysis.LeadTimeHelper;
 import taiga.util.timeAnalysis.LeadTimeStats;
+import taiga.util.timeAnalysis.LeadTimeStoryEntry;
 import ui.util.DateUtil;
 
 public class LeadTimeService extends Service<Object> {
     private Sprint sprint;
 
+    private final ObservableList<XYChart.Data<String, Number>> storyLeadTimes;
     private final ObservableList<XYChart.Data<String, Number>> notCreatedStories;
     private final ObservableList<XYChart.Data<String, Number>> inBacklogStories;
     private final ObservableList<XYChart.Data<String, Number>> inSprintStories;
@@ -28,12 +30,17 @@ public class LeadTimeService extends Service<Object> {
     private final ObservableList<XYChart.Data<String, Number>> doneStories;
 
     public LeadTimeService() {
+        this.storyLeadTimes = FXCollections.observableArrayList();
         this.notCreatedStories = FXCollections.observableArrayList();
         this.inBacklogStories = FXCollections.observableArrayList();
         this.inSprintStories = FXCollections.observableArrayList();
         this.inProgressStories = FXCollections.observableArrayList();
         this.readyForTestStories = FXCollections.observableArrayList();
         this.doneStories = FXCollections.observableArrayList();
+    }
+
+    public ObservableList<XYChart.Data<String, Number>> getStoryLeadTimes() {
+        return storyLeadTimes;
     }
 
     public ObservableList<XYChart.Data<String, Number>> getNotCreatedStories() {
@@ -80,6 +87,14 @@ public class LeadTimeService extends Service<Object> {
         return leadTimeStats;
     }
 
+    private List<LeadTimeStoryEntry> getAllStoryLeadTimes() {
+        LeadTimeHelper leadTimeHelper = new LeadTimeHelper(this.sprint.getProject());
+        return leadTimeHelper.getAllStoryLeadTimes();
+    }
+
+    private void updateStoryLeadTimes(ObservableList<XYChart.Data<String, Number>> data, List<LeadTimeStoryEntry> entries) {
+
+    }
     private void updateLeadTimes(ObservableList<XYChart.Data<String, Number>> data, List<LeadTimeStats> entries, LeadTimeCallback callback){
         SimpleDateFormat format = new SimpleDateFormat("MMM dd");
 
@@ -104,8 +119,10 @@ public class LeadTimeService extends Service<Object> {
                 }
 
                 List<LeadTimeStats> stats = getAllLeadTimeStats();
+                List<LeadTimeStoryEntry> allStoryLeadTimes = getAllStoryLeadTimes();
 
                 Platform.runLater(() -> {
+                    updateStoryLeadTimes(storyLeadTimes, allStoryLeadTimes);
                     updateLeadTimes(notCreatedStories, stats, LeadTimeStats::getNotCreated);
                     updateLeadTimes(inBacklogStories, stats, LeadTimeStats::getInBacklog);
                     updateLeadTimes(inSprintStories, stats, LeadTimeStats::getInSprint);


### PR DESCRIPTION
# US: 229

### Description of Changes:
Adds a scatter plot visualization for lead time


### PR Submitter Checklist:
- [ ] Taiga updated
- [ ] Code Compiles
- [ ] Tests Pass
- [ ] Essential code is commented using docstrings
- [ ] US acceptance criteria are met
- [ ] Static analysis checks pass


### Reviewer Checklist (Copy into your review):
```markdown
# Review comments

# Review Checklist
- [ ] Taiga updated
- [ ] Code Compiles
- [ ] Tests Pass
- [ ] Essential code is commented using docstrings
- [ ] US acceptance criteria are met
- [ ] Static analysis checks pass
```
