### PR TITLE
Issue 520: Enforce usage of Java17

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ commitments, ultimately leading to improved productivity and delivery consistenc
 
 ### Requirements and Setup
 
-- Java 17 or higher
+- Java 17
 - Maven for dependency management and running the project
   - Maven will include JavaFX in its dependencies
 - Docker

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -61,14 +61,14 @@
                 <executions>
                     <execution>
                         <id>default-cli</id>
-                        <phase>validate</phase>
                         <goals>
                             <goal>enforce</goal>
                         </goals>
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>17</version>
+                                    <version>[17, 18)</version>
+                                    <message>Java 17 is required to run this application</message>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -54,6 +54,27 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>17</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
# US: Issue 520

### Description of Changes:

Previously we did not enforce the required java version in maven. This led to users with different java versions being able to run the application, but encountering strange errors. Enforcing java 17 will ensure a uniform execution environment for the native client.

### PR Submitter Checklist:

- [x] Taiga updated
- [x] Code Compiles
- [x] Tests Pass
- [x] Essential code is commented using docstrings
- [x] US acceptance criteria are met
- [x] Static analysis checks pass

### Reviewer Checklist (Copy into your review):

```markdown
# Review comments

# Review Checklist
- [ ] Taiga updated
- [ ] Code Compiles
- [ ] Tests Pass
- [ ] Essential code is commented using docstrings
- [ ] US acceptance criteria are met
- [ ] Static analysis checks pass
```
